### PR TITLE
fix: allow reverse proxy from non standard port

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -353,7 +353,7 @@ $CFG->admin = 'admin';
 //
 // Enable when setting up advanced reverse proxy load balancing configurations,
 // it may be also necessary to enable this when using port forwarding.
-//      $CFG->reverseproxy = true;
+$CFG->reverseproxy = true;
 //
 // Enable when using external SSL appliance for performance reasons.
 // Please note that site may be accessible via http: or https:, but not both!

--- a/lib/setuplib.php
+++ b/lib/setuplib.php
@@ -900,7 +900,10 @@ function initialise_fullme() {
 
     // hopefully this will stop all those "clever" admins trying to set up moodle
     // with two different addresses in intranet and Internet
-    if (!empty($CFG->reverseproxy) && $rurl['host'] === $wwwroot['host']) {
+    // ### Following line commented By CP ### //                                                                                                  
+    // if (!empty($CFG->reverseproxy) && $rurl['host'] === $wwwroot['host']) {   
+    // ### Following line added By CP, as suggested here: https://moodle.org/mod/forum/discuss.php?d=388076#p1564638 ### //                                                                                                  
+    if (!empty($CFG->reverseproxy) && $rurl['host'] === $wwwroot['host'] && (empty($wwwroot['port']) || $rurl['port'] === $wwwroot['port'])) {
         print_error('reverseproxyabused', 'error');
     }
 


### PR DESCRIPTION
With Nginx reverse proxy in the front with PHP7-FPM in the backgroud
via FastCGI Pass, Moodle was not allowing to have a non standard port
(other than 80 or 443) in the url.

This issue has been solved as by the solution as suggested here:
https://moodle.org/mod/forum/discuss.php?d=388076#p1564638

